### PR TITLE
python-daemon 3.0.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,16 +19,15 @@ requirements:
     - python
     - pip
     # Install won't work with setuptools >69.5.1
-    - setuptools 69.5.1
+    - setuptools <=69.5.1
     - wheel
     - docutils
-    - packaging
   run:
     - python
     - lockfile >=0.10
     - setuptools
+    # docutils doesn't seem necessary here, but pip check won't pass without it.
     - docutils
-    - packaging
 
 test:
   requires:
@@ -42,10 +41,12 @@ about:
   home: https://pagure.io/python-daemon/
   description: |
     This library implements the well-behaved daemon specification of
-    :pep:`3143`, “Standard daemon process library”.
-  license: Apache-2.0
-  license_family: APACHE
-  license_file: LICENSE.ASF-2
+    PEP 3143, “Standard daemon process library”.
+  license: Apache-2.0 AND GPL-3.0-or-later
+  license_family: Other
+  license_file:
+    - LICENSE.ASF-2
+    - LICENSE.GPL-3
   summary: Library to implement a well-behaved Unix daemon process.
   dev_url: https://pagure.io/python-daemon/
   doc_url: https://pagure.io/python-daemon

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,12 +21,14 @@ requirements:
     # Install won't work with setuptools >69.5.1
     - setuptools 69.5.1
     - wheel
-    - twine
+    - docutils
+    - packaging
   run:
     - python
     - lockfile >=0.10
     - setuptools
     - docutils
+    - packaging
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,3 +1,4 @@
+# https://pagure.io/python-daemon/issue/94
 {% set version = "3.0.1" %}
 
 package:
@@ -17,13 +18,14 @@ requirements:
   host:
     - python
     - pip
-    - setuptools
+    # Install won't work with setuptools >69.5.1
+    - setuptools 69.5.1
     - wheel
     - twine
   run:
     - python
     - lockfile >=0.10
-    - setuptools >=62.4.0
+    - setuptools
     - docutils
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.3.1" %}
+{% set version = "3.0.1" %}
 
 package:
   name: python-daemon

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,11 +42,10 @@ about:
   description: |
     This library implements the well-behaved daemon specification of
     PEP 3143, “Standard daemon process library”.
-  license: Apache-2.0 AND GPL-3.0-or-later
+  license: Apache-2.0
   license_family: Other
   license_file:
     - LICENSE.ASF-2
-    - LICENSE.GPL-3
   summary: Library to implement a well-behaved Unix daemon process.
   dev_url: https://pagure.io/python-daemon/
   doc_url: https://pagure.io/python-daemon

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,11 +6,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/python-daemon/python-daemon-{{ version }}.tar.gz
-  sha256: 15c2c5e2cef563e0a5f98d542b77ba59337380b472975d2b2fd6b8c4d5cf46ca
+  sha256: 6c57452372f7eaff40934a1c03ad1826bf5e793558e87fef49131e6464b4dae5
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
   skip: True  # [win or (linux and s390x)]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
   run:
     - python
     - lockfile >=0.10
-    - setuptools
+    - setuptools >=62.4.0
     - docutils
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,11 +38,15 @@ test:
 
 about:
   home: https://pagure.io/python-daemon/
+  description: |
+    This library implements the well-behaved daemon specification of
+    :pep:`3143`, “Standard daemon process library”.
   license: Apache-2.0
   license_family: APACHE
   license_file: LICENSE.ASF-2
   summary: Library to implement a well-behaved Unix daemon process.
   dev_url: https://pagure.io/python-daemon/
+  doc_url: https://pagure.io/python-daemon
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-4950](https://anaconda.atlassian.net/browse/PKG-4950)
- [Upstream repository](https://pagure.io/python-daemon)
- [Upstream changelog/diff](https://pagure.io/python-daemon/blob/efd2c25dcbca17725050337870d094544a6c8cf6/f/ChangeLog)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/luigi-feedstock/pull/2

### Explanation of changes:

- update version, sha256, and build script
- setuptools needs to be pinned to an older version or else pip install won't work https://answers.ros.org/question/362883/fail-building-foxy-modulenotfounderror-no-module-named-setuptoolsextern/

[PKG-4950]: https://anaconda.atlassian.net/browse/PKG-4950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ